### PR TITLE
Standardise signature parameters & better handle steam disconnection event

### DIFF
--- a/src/fwens.cpp
+++ b/src/fwens.cpp
@@ -11,9 +11,9 @@ Fwens::~Fwens() {
 
 Fwens::Fwens():
 	m_steamcallback_HandleConnected(this, &Fwens::Steam_HandleSteamConnected),
-	m_steamcallback_HandleGroupRequest(this, &Fwens::Steam_HandleGroupRequest),
-	m_steamcallback_HandleDisconnected(this, &Fwens::Steam_HandleOnDisconnect),
-	m_steamcallback_HandleConnectionFailed(this, &Fwens::Steam_HandleConnectionFailed)
+	m_steamcallback_HandleGroupRequest(this, &Fwens::Steam_HandleGroupRequest)
+	//m_steamcallback_HandleDisconnected(this, &Fwens::Steam_HandleOnDisconnect),
+	//m_steamcallback_HandleConnectionFailed(this, &Fwens::Steam_HandleConnectionFailed)
 {}
 
 Fwens* Fwens::GetInstance() {
@@ -31,12 +31,7 @@ void Fwens::SetLuaInstance(GarrysMod::Lua::ILuaBase* ILuaBase)
 
 void Fwens::InitSteamAPIConnection()
 {
-	bool status = steamContext.Init();
-	if (!status)
-	{
-		return;
-	}
-	steamContext_active = true;
+	steamContext_active = steamContext.Init();
 }
 
 bool Fwens::GetSteamContextActive()
@@ -51,44 +46,101 @@ void Fwens::ClearSteamContext() {
 
 void Fwens::Steam_HandleSteamConnected(SteamServersConnected_t* result)
 {
-	bool status = GetSteamContextActive();
-	if (!status)
-	{
-		InitSteamAPIConnection();
-		return;
-	}
+
+	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+		LUA->GetField(-1, "print");
+		LUA->PushString("gfwens: We connected!");
+		LUA->Call(1, 0);
+	LUA->Pop();
 	steamContext_active = true;
 }
 
+/*
 void Fwens::Steam_HandleOnDisconnect(SteamServersDisconnected_t* result)
 {
-	ClearSteamContext();
+	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+		LUA->GetField(-1, "print");
+		LUA->PushString("gfwens: We disconnected!!");
+		LUA->Call(1, 0);
+	LUA->Pop();
+	steamContext_active = false;
 }
 
 void Fwens::Steam_HandleConnectionFailed(SteamServerConnectFailure_t* result)
 {
-	ClearSteamContext();
-}
+	steamContext_active = false;
+	/*if (!result->m_bStillRetrying) {
+		ClearSteamContext();
+		return;
+	}*/
+
+	/*if (!result) {
+		return;
+	}
+
+	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+	LUA->GetField(-1, "print");
+	LUA->PushString("gfwens: aaaaaaaaaaaaaa");
+	LUA->Call(1, 0);
+	LUA->Pop();
+
+	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+		LUA->GetField(-1, "print");
+		LUA->PushString("gfwens: Connection failed, oh no!");
+		LUA->PushBool(result->m_bStillRetrying);
+		LUA->Call(2, 0);
+	LUA->Pop();
+	
+	//ClearSteamContext();
+}*/
 
 void Fwens::RequestUserGroupStatus(CSteamID player, CSteamID groupID)
 {
-	if (GetSteamContextActive() == false) {
+	if (GetSteamContextActive() == false) 
+	{
 		return;
 	}
 
 	ISteamGameServer* steamGameServer = steamContext.SteamGameServer();
+
+	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+	LUA->GetField(-1, "print");
+	LUA->PushString("gfwens: got isteamgameserver");
+	LUA->Call(1, 0);
+	LUA->Pop();
+
 	steamGameServer->RequestUserGroupStatus(player, groupID);
 }
 
 
 void Fwens::Steam_HandleGroupRequest(GSClientGroupStatus_t* pCallback)
 {
+
+	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+	LUA->GetField(-1, "print");
+	LUA->PushString("gfwens: entered callback");
+	LUA->Call(1, 0);
+	LUA->Pop();
+
+
 	// CSteamID.Render() no longer appears to function, we'll cast these manually.
 	char userBuffer[18];
 	char groupBuffer[19];
 
+	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+	LUA->GetField(-1, "print");
+	LUA->PushString("gfwens: waterloo");
+	LUA->Call(1, 0);
+	LUA->Pop();
+
 	snprintf(userBuffer, sizeof(userBuffer), "%llu", pCallback->m_SteamIDUser.ConvertToUint64());
 	snprintf(groupBuffer, sizeof(groupBuffer), "%llu", pCallback->m_SteamIDGroup.ConvertToUint64());
+
+	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+	LUA->GetField(-1, "print");
+	LUA->PushString("gfwens: about to do magic with the hook run stuff");
+	LUA->Call(1, 0);
+	LUA->Pop();
 	
 	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
 	LUA->GetField(-1, "hook");

--- a/src/fwens.cpp
+++ b/src/fwens.cpp
@@ -98,6 +98,7 @@ void Fwens::RequestUserGroupStatus(CSteamID player, CSteamID groupID)
 {
 	if (GetSteamContextActive() == false) 
 	{
+		LUA->ThrowError("No connection to the Steam API. Is Steam up?");
 		return;
 	}
 

--- a/src/fwens.cpp
+++ b/src/fwens.cpp
@@ -112,7 +112,6 @@ void Fwens::RequestUserGroupStatus(CSteamID player, CSteamID groupID)
 	steamGameServer->RequestUserGroupStatus(player, groupID);
 }
 
-
 void Fwens::Steam_HandleGroupRequest(GSClientGroupStatus_t* pCallback)
 {
 	// CSteamID.Render() no longer appears to function, we'll cast these manually.

--- a/src/fwens.cpp
+++ b/src/fwens.cpp
@@ -49,7 +49,7 @@ void Fwens::ClearSteamContext() {
 	steamContext.Clear();
 }
 
-void Fwens::Steam_HandleSteamConnected(SteamServersConnected_t* policyResponse)
+void Fwens::Steam_HandleSteamConnected(SteamServersConnected_t* result)
 {
 	bool status = GetSteamContextActive();
 	if (!status)
@@ -60,12 +60,12 @@ void Fwens::Steam_HandleSteamConnected(SteamServersConnected_t* policyResponse)
 	steamContext_active = true;
 }
 
-void Fwens::Steam_HandleOnDisconnect(SteamServersDisconnected_t* policyResponse)
+void Fwens::Steam_HandleOnDisconnect(SteamServersDisconnected_t* result)
 {
 	ClearSteamContext();
 }
 
-void Fwens::Steam_HandleConnectionFailed(SteamServerConnectFailure_t* policyResponse)
+void Fwens::Steam_HandleConnectionFailed(SteamServerConnectFailure_t* result)
 {
 	ClearSteamContext();
 }

--- a/src/fwens.cpp
+++ b/src/fwens.cpp
@@ -45,8 +45,8 @@ bool Fwens::GetSteamContextActive()
 }
 
 void Fwens::ClearSteamContext() {
-	steamContext.Clear();
 	steamContext_active = false;
+	steamContext.Clear();
 }
 
 void Fwens::Steam_HandleOnPolicyResponse(GSPolicyResponse_t* policyResponse)
@@ -60,7 +60,7 @@ void Fwens::Steam_HandleOnPolicyResponse(GSPolicyResponse_t* policyResponse)
 	steamContext_active = true;
 }
 
-void Fwens::Steam_HandleSteamConnected(SteamServersConnected_t* connnected)
+void Fwens::Steam_HandleSteamConnected(SteamServersConnected_t* policyResponse)
 {
 	bool status = GetSteamContextActive();
 	if (!status)
@@ -71,20 +71,17 @@ void Fwens::Steam_HandleSteamConnected(SteamServersConnected_t* connnected)
 	steamContext_active = true;
 }
 
-void Fwens::Steam_HandleOnDisconnect(SteamServersDisconnected_t* something)
+void Fwens::Steam_HandleOnDisconnect(SteamServersDisconnected_t* policyResponse)
 {
-	steamContext_active = false;
-	bool status = GetSteamContextActive();
-	if (!status)
-	{
-		InitSteamAPIConnection();
-		return;
-	}
-	steamContext_active = true;
+	ClearSteamContext();
 }
 
 void Fwens::RequestUserGroupStatus(CSteamID player, CSteamID groupID)
 {
+	if (GetSteamContextActive() == false) {
+		return;
+	}
+
 	ISteamGameServer* steamGameServer = steamContext.SteamGameServer();
 	steamGameServer->RequestUserGroupStatus(player, groupID);
 }

--- a/src/fwens.cpp
+++ b/src/fwens.cpp
@@ -2,7 +2,8 @@
 #include <stdlib.h>
 
 Fwens* Fwens::instance = NULL;
-Fwens::~Fwens() {
+Fwens::~Fwens() 
+{
 	if (GetSteamContextActive())
 	{
 		ClearSteamContext();
@@ -16,8 +17,10 @@ Fwens::Fwens():
 	m_steamcallback_HandleConnectionFailed(this, &Fwens::Steam_HandleConnectionFailed)
 {}
 
-Fwens* Fwens::GetInstance() {
-	if (instance == NULL) {
+Fwens* Fwens::GetInstance() 
+{
+	if (instance == NULL) 
+	{
 		instance = new Fwens;
 	}
 
@@ -40,14 +43,16 @@ bool Fwens::GetSteamContextActive()
 	return steamContext_active;
 }
 
-void Fwens::ClearSteamContext() {
+void Fwens::ClearSteamContext() 
+{
 	steamContext_active = false;
 	steamContext.Clear();
 }
 
 void Fwens::Steam_HandleSteamConnected(SteamServersConnected_t* result)
 {
-	if (!GetSteamContextActive()) {
+	if (!GetSteamContextActive()) 
+	{
 		InitSteamAPIConnection();
 		return;
 	}
@@ -64,7 +69,8 @@ void Fwens::NotifyLuaSteamConnectionEvent(bool connected)
 		LUA->PushBool(connected);
 
 	int returnValue = LUA->PCall(2, 0, 0);
-	if (returnValue != 0) {
+	if (returnValue != 0) 
+	{
 		LUA->Remove(1);
 		LUA->Remove(1);
 
@@ -87,7 +93,8 @@ void Fwens::Steam_HandleOnDisconnect(SteamServersDisconnected_t* result)
 void Fwens::Steam_HandleConnectionFailed(SteamServerConnectFailure_t* result)
 {
 	steamContext_active = false;
-	if (!result->m_bStillRetrying) {
+	if (!result->m_bStillRetrying) 
+	{
 		ClearSteamContext();
 		InitSteamAPIConnection();
 		return;
@@ -103,7 +110,8 @@ void Fwens::RequestUserGroupStatus(CSteamID player, CSteamID groupID)
 	}
 
 	ISteamGameServer* steamGameServer = steamContext.SteamGameServer();
-	if (steamGameServer == NULL) {
+	if (steamGameServer == NULL) 
+	{
 		// This shouldn't really ever happen. But when it rarely does, gracefully bow out.
 		LUA->ThrowError("ISteamGameServer is NULL. Invalid Steam connection.");
 		return;
@@ -140,7 +148,8 @@ void Fwens::Steam_HandleGroupRequest(GSClientGroupStatus_t* pCallback)
 			LUA->SetField(-2, "groupID64");
 
 	int returnValue = LUA->PCall(2, 0, 0);
-	if (returnValue != 0) {
+	if (returnValue != 0) 
+	{
 		// Dump our two current tables to simplify this. Can't pop because LIFO.
 		LUA->Remove(1);
 		LUA->Remove(1);

--- a/src/fwens.cpp
+++ b/src/fwens.cpp
@@ -13,7 +13,7 @@ Fwens::Fwens():
 	m_steamcallback_HandleConnected(this, &Fwens::Steam_HandleSteamConnected),
 	m_steamcallback_HandleGroupRequest(this, &Fwens::Steam_HandleGroupRequest),
 	m_steamcallback_HandleDisconnected(this, &Fwens::Steam_HandleOnDisconnect),
-	m_steamcallback_HandlePolicyResponse(this, &Fwens::Steam_HandleOnPolicyResponse)
+	m_steamcallback_HandleConnectionFailed(this, &Fwens::Steam_HandleConnectionFailed)
 {}
 
 Fwens* Fwens::GetInstance() {
@@ -49,17 +49,6 @@ void Fwens::ClearSteamContext() {
 	steamContext.Clear();
 }
 
-void Fwens::Steam_HandleOnPolicyResponse(GSPolicyResponse_t* policyResponse)
-{
-	bool status = GetSteamContextActive();
-	if (!status)
-	{
-		InitSteamAPIConnection();
-		return;
-	}
-	steamContext_active = true;
-}
-
 void Fwens::Steam_HandleSteamConnected(SteamServersConnected_t* policyResponse)
 {
 	bool status = GetSteamContextActive();
@@ -72,6 +61,11 @@ void Fwens::Steam_HandleSteamConnected(SteamServersConnected_t* policyResponse)
 }
 
 void Fwens::Steam_HandleOnDisconnect(SteamServersDisconnected_t* policyResponse)
+{
+	ClearSteamContext();
+}
+
+void Fwens::Steam_HandleConnectionFailed(SteamServerConnectFailure_t* policyResponse)
 {
 	ClearSteamContext();
 }

--- a/src/fwens.cpp
+++ b/src/fwens.cpp
@@ -59,6 +59,10 @@ void Fwens::Steam_HandleSteamConnected(SteamServersConnected_t* result)
 	steamContext_active = true;
 }
 
+void Fwens::NotifyLuaSteamDisconnectionEvent()
+{
+
+}
 
 void Fwens::Steam_HandleOnDisconnect(SteamServersDisconnected_t* result)
 {
@@ -78,15 +82,11 @@ void Fwens::Steam_HandleConnectionFailed(SteamServerConnectFailure_t* result)
 		return;
 	}*/
 
-	/*if (!result) {
-		return;
-	}
-
-	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+	/*LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
 	LUA->GetField(-1, "print");
 	LUA->PushString("gfwens: aaaaaaaaaaaaaa");
 	LUA->Call(1, 0);
-	LUA->Pop();
+	LUA->Pop();*/
 
 	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
 		LUA->GetField(-1, "print");

--- a/src/fwens.h
+++ b/src/fwens.h
@@ -18,6 +18,7 @@ public:
 	void SetLuaInstance(GarrysMod::Lua::ILuaBase* ILuaBase);
 	void RequestUserGroupStatus(CSteamID player, CSteamID groupID);
 	void ClearSteamContext();	
+	void NotifyLuaSteamDisconnectionEvent();
 	
 	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleSteamConnected, SteamServersConnected_t, m_steamcallback_HandleConnected);
 	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleGroupRequest, GSClientGroupStatus_t, m_steamcallback_HandleGroupRequest);

--- a/src/fwens.h
+++ b/src/fwens.h
@@ -22,5 +22,6 @@ public:
 	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleSteamConnected, SteamServersConnected_t, m_steamcallback_HandleConnected);
 	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleGroupRequest, GSClientGroupStatus_t, m_steamcallback_HandleGroupRequest);
 	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleOnDisconnect, SteamServersDisconnected_t, m_steamcallback_HandleDisconnected);
-	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleOnPolicyResponse, GSPolicyResponse_t, m_steamcallback_HandlePolicyResponse);
+	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleConnectionFailed, SteamServerConnectFailure_t, m_steamcallback_HandleConnectionFailed);
+
 };

--- a/src/fwens.h
+++ b/src/fwens.h
@@ -18,11 +18,10 @@ public:
 	void SetLuaInstance(GarrysMod::Lua::ILuaBase* ILuaBase);
 	void RequestUserGroupStatus(CSteamID player, CSteamID groupID);
 	void ClearSteamContext();	
-	void NotifyLuaSteamDisconnectionEvent();
+	void NotifyLuaSteamConnectionEvent(bool connected);
 	
 	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleSteamConnected, SteamServersConnected_t, m_steamcallback_HandleConnected);
 	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleGroupRequest, GSClientGroupStatus_t, m_steamcallback_HandleGroupRequest);
 	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleOnDisconnect, SteamServersDisconnected_t, m_steamcallback_HandleDisconnected);
 	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleConnectionFailed, SteamServerConnectFailure_t, m_steamcallback_HandleConnectionFailed);
-
 };

--- a/src/fwens.h
+++ b/src/fwens.h
@@ -21,7 +21,7 @@ public:
 	
 	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleSteamConnected, SteamServersConnected_t, m_steamcallback_HandleConnected);
 	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleGroupRequest, GSClientGroupStatus_t, m_steamcallback_HandleGroupRequest);
-	//STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleOnDisconnect, SteamServersDisconnected_t, m_steamcallback_HandleDisconnected);
-	//STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleConnectionFailed, SteamServerConnectFailure_t, m_steamcallback_HandleConnectionFailed);
+	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleOnDisconnect, SteamServersDisconnected_t, m_steamcallback_HandleDisconnected);
+	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleConnectionFailed, SteamServerConnectFailure_t, m_steamcallback_HandleConnectionFailed);
 
 };

--- a/src/fwens.h
+++ b/src/fwens.h
@@ -21,7 +21,7 @@ public:
 	
 	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleSteamConnected, SteamServersConnected_t, m_steamcallback_HandleConnected);
 	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleGroupRequest, GSClientGroupStatus_t, m_steamcallback_HandleGroupRequest);
-	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleOnDisconnect, SteamServersDisconnected_t, m_steamcallback_HandleDisconnected);
-	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleConnectionFailed, SteamServerConnectFailure_t, m_steamcallback_HandleConnectionFailed);
+	//STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleOnDisconnect, SteamServersDisconnected_t, m_steamcallback_HandleDisconnected);
+	//STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleConnectionFailed, SteamServerConnectFailure_t, m_steamcallback_HandleConnectionFailed);
 
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,6 +67,13 @@ GMOD_MODULE_OPEN()
 
 	Fwens* fwenVar = Fwens::GetInstance();
 	fwenVar->SetLuaInstance(LUA);
+
+	// Exists for changelevel purposes. Will silently fail during first boot of the server.
+	if (!fwenVar->GetSteamContextActive())
+	{
+		fwenVar->InitSteamAPIConnection();
+	}
+	
 	return 0;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,12 +46,6 @@ LUA_FUNCTION(GetInSteamGroup)
 		return 0;
 	}
 
-	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
-	LUA->GetField(-1, "print");
-	LUA->PushString("gfwens: about to request");
-	LUA->Call(1, 0);
-	LUA->Pop();
-
 	fwenVar->RequestUserGroupStatus(player, groupID);
 	return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,12 +40,6 @@ LUA_FUNCTION(GetInSteamGroup)
 	}
 
 	Fwens* fwenVar = Fwens::GetInstance();
-	if (!fwenVar->GetSteamContextActive())
-	{
-		LUA->ThrowError("No connection to the Steam API. Is Steam up?");
-		return 0;
-	}
-
 	fwenVar->RequestUserGroupStatus(player, groupID);
 	return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,10 +46,15 @@ LUA_FUNCTION(GetInSteamGroup)
 		return 0;
 	}
 
+	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+	LUA->GetField(-1, "print");
+	LUA->PushString("gfwens: about to request");
+	LUA->Call(1, 0);
+	LUA->Pop();
+
 	fwenVar->RequestUserGroupStatus(player, groupID);
 	return 0;
 }
-
 
 GMOD_MODULE_OPEN()
 {
@@ -62,7 +67,7 @@ GMOD_MODULE_OPEN()
 		LUA->SetField(-2, "fwens");
 
 		LUA->GetField(-1, "print");
-		LUA->PushString("gfwens v1 loaded.");
+		LUA->PushString("gfwens v1.1 loaded.");
 		LUA->Call(1, 0);
 	LUA->Pop();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,12 +73,6 @@ GMOD_MODULE_OPEN()
 
 	Fwens* fwenVar = Fwens::GetInstance();
 	fwenVar->SetLuaInstance(LUA);
-
-	if (!fwenVar->GetSteamContextActive())
-	{
-		fwenVar->InitSteamAPIConnection();
-	}
-	
 	return 0;
 }
 


### PR DESCRIPTION
- OnDisconnected will now clear the Steam context instead of trying to instantly reconnect
- RequestUserGroupStatus won't attempt to check group status and instead just return false in the event of no connection. 