### PR TITLE
Add meaningful versioning + preprocessor definitions

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -110,7 +110,7 @@ jobs:
 
     # We need multilib otherwise we'll get the wrong arch for *nix
     - run: |
-        sudo apt install gcc-multilib g++-multilib -y
+        sudo apt update && sudo apt install gcc-multilib g++-multilib -y
         cd gfwens
         chmod +x ./premake5
         ./premake5 gmake2

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -97,7 +97,7 @@ jobs:
         path: gfwens/deps
 
     - run: |
-        sudo apt update && sudo apt install gcc-multilib g++-multilib -y
+        sudo apt install gcc-multilib g++-multilib -y
         cd gfwens
         chmod +x ./premake5
         ./premake5 gmake2

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -8,7 +8,6 @@ on:
       - "README.md"
       - 'examples/**'
       - ".gitignore"
-      - ".github/workflows/build-pr.yml" 
       - ".github/workflows/build-master.yml" 
 
 env:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -105,8 +105,11 @@ jobs:
         make config=release_x64
 
   release:
-    name: cleanup
+    name: Build Cleanup
     runs-on: ubuntu-18.04
+    if: always()
+      needs: [build-linux, build-win]
+    
     steps:
 
       - uses: geekyeggo/delete-artifact@v1

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -96,11 +96,22 @@ jobs:
         name: sdk-persistence
         path: gfwens/deps
 
-    # We need multilib otherwise we'll get the wrong arch for *nix
     - run: |
-        sudo apt install gcc-multilib g++-multilib -y
+        sudo apt update && sudo apt install gcc-multilib g++-multilib -y
         cd gfwens
         chmod +x ./premake5
         ./premake5 gmake2
         make config=release_x32
         make config=release_x64
+
+  release:
+    name: cleanup
+    runs-on: ubuntu-18.04
+    steps:
+
+      - uses: geekyeggo/delete-artifact@v1
+        with:
+          name: |
+            premake-persistence
+            sdk-persistence
+    

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -111,7 +111,6 @@ jobs:
       needs: [build-linux, build-win]
     
     steps:
-
       - uses: geekyeggo/delete-artifact@v1
         with:
           name: |

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -2,7 +2,7 @@ name: Build gFwens (pull request)
 
 on:
   push:
-    - pull_request
+    pull_request:
 
     paths-ignore:
       - "README.md"

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -97,7 +97,7 @@ jobs:
         path: gfwens/deps
 
     - run: |
-        sudo apt install gcc-multilib g++-multilib -y
+        sudo apt update && sudo apt install gcc-multilib g++-multilib -y
         cd gfwens
         chmod +x ./premake5
         ./premake5 gmake2

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -110,10 +110,10 @@ jobs:
     if: always()
       needs: [build-linux, build-win]
     
-    steps:
-      - uses: geekyeggo/delete-artifact@v1
-        with:
-          name: |
-            premake-persistence
-            sdk-persistence
-    
+      steps:
+        - uses: geekyeggo/delete-artifact@v1
+          with:
+            name: |
+              premake-persistence
+              sdk-persistence
+      

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -107,8 +107,8 @@ jobs:
   release:
     name: Build Cleanup
     runs-on: ubuntu-18.04
-    if: ${{ always() }}
-      needs: [build-linux, build-win]
+    if: always()
+    needs: [build-linux, build-win]
     
     steps:
       - uses: geekyeggo/delete-artifact@v1

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -107,13 +107,13 @@ jobs:
   release:
     name: Build Cleanup
     runs-on: ubuntu-18.04
-    if: always()
+    if: ${{ always() }}
       needs: [build-linux, build-win]
     
-      steps:
-        - uses: geekyeggo/delete-artifact@v1
-          with:
-            name: |
-              premake-persistence
-              sdk-persistence
-      
+    steps:
+      - uses: geekyeggo/delete-artifact@v1
+        with:
+          name: |
+            premake-persistence
+            sdk-persistence
+    

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,15 +1,15 @@
-name: Build gFwens (push to master)
+name: Build gFwens (pull request)
 
 on:
   push:
-    branches: [ master ]
+    - pull_request
 
     paths-ignore:
       - "README.md"
       - 'examples/**'
       - ".gitignore"
-      - ".github/workflows/build-master.yml" 
       - ".github/workflows/build-pr.yml" 
+      - ".github/workflows/build-master.yml" 
 
 env:
   STEAMWORKS_LIB_BASEDIR: "./deps" 
@@ -70,17 +70,6 @@ jobs:
         ./premake5.exe vs2019
         MSBuild.exe /p:Configuration=Release
         MSBuild.exe /p:Configuration=Release /property:Platform=x64
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: gmsv_fwens_win32.dll
-        path: gfwens\bin\release\gmsv_fwens_win32.dll
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: gmsv_fwens_win64.dll
-        path: gfwens\bin\release\gmsv_fwens_win64.dll
-
 ###
 
   build-linux:
@@ -116,57 +105,3 @@ jobs:
         ./premake5 gmake2
         make config=release_x32
         make config=release_x64
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: gmsv_fwens_linux.dll
-        path: gfwens/bin/release/gmsv_fwens_linux.dll
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: gmsv_fwens_linux64.dll
-        path: gfwens/bin/release/gmsv_fwens_linux64.dll
-    
-  release:
-    runs-on: ubuntu-18.04
-    needs: [build-win, build-linux]
-
-    steps:
-                    
-      - name: Get short hash
-        id: gensha
-        run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
-
-      - uses: actions/download-artifact@v2  
-        with:
-          name: gmsv_fwens_linux.dll
-
-      - uses: actions/download-artifact@v2  
-        with:
-          name: gmsv_fwens_linux64.dll
-
-      - uses: actions/download-artifact@v2  
-        with:
-          name: gmsv_fwens_win32.dll
-
-      - uses: actions/download-artifact@v2  
-        with:
-          name: gmsv_fwens_win64.dll
-
-      - uses: ncipollo/release-action@v1
-        with: 
-          artifacts:  "*.dll"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.gensha.outputs.sha8 }}
-          omitBody: true
-
-      - uses: geekyeggo/delete-artifact@v1
-        with:
-          name: |
-            gmsv_fwens_win32.dll
-            gmsv_fwens_win64.dll
-            gmsv_fwens_linux.dll
-            gmsv_fwens_linux64.dll
-            premake-persistence
-            sdk-persistence
-    

--- a/premake5.lua
+++ b/premake5.lua
@@ -11,6 +11,12 @@ project "gmsv_gfwens"
 
     local gmodBaseDir =  os.getenv("GMODHEADERS") or ""
     local steamworksBaseDir = os.getenv("STEAMWORKS_LIB_BASEDIR") or ""
+    local hashVersion = function() if os.getenv("GITHUB_SHA") ~= nil then 
+            return string.format("GitHub %s", string.sub(os.getenv("GITHUB_SHA"), 1, 8))
+        else 
+            return "UNKNOWN-GIT-SHA"
+        end 
+    end
    
     includedirs { "../gmodheaders/include", "../steamworks", gmodBaseDir, steamworksBaseDir}
     targetname ("gmsv_fwens")
@@ -18,13 +24,13 @@ project "gmsv_gfwens"
     targetextension ".dll"
 
     filter "configurations:Debug"
-        defines { "DEBUG", "_CRT_SECURE_NO_WARNINGS" }
+        defines { "DEBUG", "_CRT_SECURE_NO_WARNINGS", string.format("GFWENS_VERSION=%q", hashVersion()), string.format("GFWENS_BUILD_DATE=%q", os.date("%b %d %Y"))}
         symbols "On"
         targetdir "bin/debug/"
         objdir "bin/debug/"
 
     filter "configurations:Release"
-        defines { "NDEBUG", "_CRT_SECURE_NO_WARNINGS" }
+        defines { "NDEBUG", "_CRT_SECURE_NO_WARNINGS", string.format("GFWENS_VERSION=%q", hashVersion()), string.format("GFWENS_BUILD_DATE=%q", os.date("%b %d %Y"))}
         optimize "On"
         symbols "off"
         targetdir "bin/release/"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,18 +44,30 @@ LUA_FUNCTION(GetInSteamGroup)
 	return 0;
 }
 
+#ifndef GFWENS_VERSION
+const char* GFWENS_VERSION = "LOCAL";
+const char* GFWENS_BUILD_DATE = __DATE__;
+#endif
+
 GMOD_MODULE_OPEN()
 {
+	const int buffSize = 60;
+	char versionBuffer[buffSize];
+	snprintf(versionBuffer, buffSize, "gfwens %s (%s) loaded.", GFWENS_VERSION, GFWENS_BUILD_DATE);
+
 	LUA->PushSpecial(SPECIAL_GLOB);
-		LUA->CreateTable();
+	LUA->CreateTable();
 
 		LUA->PushCFunction(GetInSteamGroup);
 		LUA->SetField(-2, "GetInSteamGroup");
 
+		LUA->PushString(GFWENS_VERSION);
+		LUA->SetField(-2, "version");
+
 		LUA->SetField(-2, "fwens");
 
 		LUA->GetField(-1, "print");
-		LUA->PushString("gfwens v1.1 loaded.");
+		LUA->PushString(versionBuffer);
 		LUA->Call(1, 0);
 	LUA->Pop();
 
@@ -67,7 +79,7 @@ GMOD_MODULE_OPEN()
 	{
 		fwenVar->InitSteamAPIConnection();
 	}
-	
+
 	return 0;
 }
 


### PR DESCRIPTION
While I don't envision there ever being a huge need to push through constant / major updates, the version string also rarely ever got updated in an appropriate manner. So this PR adds the following: 

- Exposes fwens.version to the lua interface, meaning developers can bind to a version / check for a difference if they want
- Exposed `GFWENS_VERSION` and `GFWENS_BUILD_DATE` to the C preprocessor so we can define the version straight from the build process
  - If built locally, will default to a string of `LOCAL` and uses the `__DATE__` macro instead
  - Premake will attempt to glean the data via the appropriate lua functions. 
