### PR TITLE
Add support for new Steamworks

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -33,7 +33,17 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       with:
-        name: sdk-persistence
+        name: sdk-persistence-32
+        path: ./sdk*
+
+    # Dealing with the difference in the x64 steamworks requirements
+    - run: |
+        rm -R ./sdk
+        wget $STEAMWORKS_SDK_URL_150 -qO- | busybox unzip -
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: sdk-persistence-64
         path: ./sdk*
 
 ###
@@ -41,8 +51,11 @@ jobs:
   build-win:
     runs-on: windows-2019
     needs: fetch-dependencies
-    steps:
+    strategy:
+      matrix:
+        arch: [32, 64]
 
+    steps:
     - uses: actions/checkout@v2
       with:
         repository: facepunch/gmod-module-base
@@ -60,34 +73,41 @@ jobs:
 
     - uses: actions/download-artifact@v2
       with:
-        name: sdk-persistence
+        name: sdk-persistence-${{matrix.arch}}
         path: gfwens/deps
 
     - uses: microsoft/setup-msbuild@v1.0.2
 
-    - run: |
+    # Dumb way of doing this but oh well. Saves fight premake on this.
+    - name: "Compile Binary"
+      if: ${{ matrix.arch == 64 }}
+      run: |
+        cd gfwens
+        ./premake5.exe vs2019
+        MSBuild.exe /p:Configuration=Release /property:Platform=x${{matrix.arch}}
+
+    - name: "Compile Binary"
+      if: ${{ matrix.arch != 64 }}
+      run: |
         cd gfwens
         ./premake5.exe vs2019
         MSBuild.exe /p:Configuration=Release
-        MSBuild.exe /p:Configuration=Release /property:Platform=x64
 
     - uses: actions/upload-artifact@v2
       with:
-        name: gmsv_fwens_win32.dll
-        path: gfwens\bin\release\gmsv_fwens_win32.dll
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: gmsv_fwens_win64.dll
-        path: gfwens\bin\release\gmsv_fwens_win64.dll
-
+        name: gmsv_fwens_win${{matrix.arch}}.dll
+        path: gfwens\bin\release\gmsv_fwens_win${{matrix.arch}}.dll
 ###
 
   build-linux:
     runs-on: ubuntu-18.04
     needs: fetch-dependencies
-    steps:
 
+    strategy:
+      matrix:
+        arch: [32, 64]
+
+    steps:
     - uses: actions/checkout@v2
       with:
         repository: facepunch/gmod-module-base
@@ -105,34 +125,34 @@ jobs:
 
     - uses: actions/download-artifact@v2
       with:
-        name: sdk-persistence
+        name: sdk-persistence-${{matrix.arch}}
         path: gfwens/deps
 
-    # We need multilib otherwise we'll get the wrong arch for *nix
-    - run: |
+    - name: "Compile Binary"
+      run: |
         sudo apt update && sudo apt install gcc-multilib g++-multilib -y
         cd gfwens
         chmod +x ./premake5
         ./premake5 gmake2
-        make config=release_x32
-        make config=release_x64
+        make config=release_x${{matrix.arch}}
 
     - uses: actions/upload-artifact@v2
+      if: ${{ matrix.arch != 64 }}
       with:
         name: gmsv_fwens_linux.dll
         path: gfwens/bin/release/gmsv_fwens_linux.dll
 
     - uses: actions/upload-artifact@v2
+      if: ${{ matrix.arch == 64 }}
       with:
-        name: gmsv_fwens_linux64.dll
-        path: gfwens/bin/release/gmsv_fwens_linux64.dll
+        name: gmsv_fwens_linux${{matrix.arch}}.dll
+        path: gfwens/bin/release/gmsv_fwens_linux${{matrix.arch}}.dll
     
   release:
     runs-on: ubuntu-18.04
     needs: [build-win, build-linux]
 
     steps:
-                    
       - name: Get short hash
         id: gensha
         run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
@@ -168,5 +188,6 @@ jobs:
             gmsv_fwens_linux.dll
             gmsv_fwens_linux64.dll
             premake-persistence
-            sdk-persistence
+            sdk-persistence-32
+            sdk-persistence-64
     

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       with:
-        name: premake-persistence-32
+        name: premake-persistence
         path: ./premake*
 
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -75,13 +75,23 @@ jobs:
         name: sdk-persistence-${{matrix.arch}}
         path: gfwens/deps
 
-        
+    
     - uses: microsoft/setup-msbuild@v1.0.2
+
+    # Dumb way of doing this but oh well. Saves fight premake on this.
     - name: "Compile Binary"
+      if: ${{ matrix.arch == 64 }}
       run: |
         cd gfwens
         ./premake5.exe vs2019
         MSBuild.exe /p:Configuration=Release /property:Platform=x${{matrix.arch}}
+
+    - name: "Compile Binary"
+      if: ${{ matrix.arch != 64 }}
+      run: |
+        cd gfwens
+        ./premake5.exe vs2019
+        MSBuild.exe /p:Configuration=Release
 ###
 
   build-linux:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        arch: [32, 64]
+        arch: [86, 64]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,12 +26,22 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       with:
-        name: premake-persistence
+        name: premake-persistence-32
         path: ./premake*
 
     - uses: actions/upload-artifact@v2
       with:
-        name: sdk-persistence
+        name: sdk-persistence-32
+        path: ./sdk*
+
+    # Dealing with the difference in the x64 steamworks requirements
+    - run: |
+        rm -R ./sdk
+        wget $STEAMWORKS_SDK_URL_150 -qO- | busybox unzip -
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: sdk-persistence-64
         path: ./sdk*
 
 ###
@@ -39,8 +49,12 @@ jobs:
   build-win:
     runs-on: windows-2019
     needs: fetch-dependencies
-    steps:
 
+    strategy:
+      matrix:
+        arch: [32, 64]
+
+    steps:
     - uses: actions/checkout@v2
       with:
         repository: facepunch/gmod-module-base
@@ -58,21 +72,26 @@ jobs:
 
     - uses: actions/download-artifact@v2
       with:
-        name: sdk-persistence
+        name: sdk-persistence-${{matrix.arch}}
         path: gfwens/deps
 
     - uses: microsoft/setup-msbuild@v1.0.2
-
     - run: |
         cd gfwens
         ./premake5.exe vs2019
-        MSBuild.exe /p:Configuration=Release
-        MSBuild.exe /p:Configuration=Release /property:Platform=x64
+        MSBuild.exe /p:Configuration=Release=x${{matrix.arch}}
+       # MSBuild.exe /p:Configuration=Release /property:Platform=x64
 ###
 
   build-linux:
     runs-on: ubuntu-18.04
     needs: fetch-dependencies
+
+    strategy:
+      matrix:
+        arch: [32, 64]
+
+
     steps:
 
     - uses: actions/checkout@v2
@@ -92,7 +111,7 @@ jobs:
 
     - uses: actions/download-artifact@v2
       with:
-        name: sdk-persistence
+        name: sdk-persistence-${{matrix.arch}}
         path: gfwens/deps
 
     - run: |
@@ -100,8 +119,7 @@ jobs:
         cd gfwens
         chmod +x ./premake5
         ./premake5 gmake2
-        make config=release_x32
-        make config=release_x64
+        make config=release_x${{matrix.arch}}
 
   release:
     name: Build Cleanup
@@ -114,5 +132,6 @@ jobs:
         with:
           name: |
             premake-persistence
-            sdk-persistence
+            sdk-persistence-32
+            sdk-persistence-64
     

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,11 +13,11 @@ env:
   STEAMWORKS_LIB_BASEDIR: "./deps" 
 
 jobs:
-
   fetch-dependencies:
     runs-on: ubuntu-18.04
     env:
       STEAMWORKS_URL:  ${{ secrets.STEAMWORKS_SDK_URL }}
+      STEAMWORKS_SDK_URL_150:  ${{ secrets.STEAMWORKS_SDK_URL_150 }}
     steps:
     - run: |
         wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha15/premake-5.0.0-alpha15-windows.zip -qO- | busybox unzip -

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -75,11 +75,13 @@ jobs:
         name: sdk-persistence-${{matrix.arch}}
         path: gfwens/deps
 
+        
     - uses: microsoft/setup-msbuild@v1.0.2
-    - run: |
+    - name: "Compile Binary"
+      run: |
         cd gfwens
         ./premake5.exe vs2019
-        MSBuild.exe /p:Configuration=Release /property:x${{matrix.arch}}
+        MSBuild.exe /p:Configuration=Release /property:Platform=x${{matrix.arch}}
        # MSBuild.exe /p:Configuration=Release /property:Platform=x64
 ###
 
@@ -114,7 +116,8 @@ jobs:
         name: sdk-persistence-${{matrix.arch}}
         path: gfwens/deps
 
-    - run: |
+    - name: "Compile Binary"
+      run: |
         sudo apt update && sudo apt install gcc-multilib g++-multilib -y
         cd gfwens
         chmod +x ./premake5

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -79,7 +79,7 @@ jobs:
     - run: |
         cd gfwens
         ./premake5.exe vs2019
-        MSBuild.exe /p:Configuration=Release=x${{matrix.arch}}
+        MSBuild.exe /p:Configuration=Release /property:x${{matrix.arch}}
        # MSBuild.exe /p:Configuration=Release /property:Platform=x64
 ###
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,7 +31,7 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       with:
-        name: sdk-persistence-86
+        name: sdk-persistence-32
         path: ./sdk*
 
     # Dealing with the difference in the x64 steamworks requirements
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        arch: [86, 64]
+        arch: [32, 64]
 
     steps:
     - uses: actions/checkout@v2
@@ -82,7 +82,6 @@ jobs:
         cd gfwens
         ./premake5.exe vs2019
         MSBuild.exe /p:Configuration=Release /property:Platform=x${{matrix.arch}}
-       # MSBuild.exe /p:Configuration=Release /property:Platform=x64
 ###
 
   build-linux:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -75,7 +75,6 @@ jobs:
         name: sdk-persistence-${{matrix.arch}}
         path: gfwens/deps
 
-    
     - uses: microsoft/setup-msbuild@v1.0.2
 
     # Dumb way of doing this but oh well. Saves fight premake on this.
@@ -102,9 +101,7 @@ jobs:
       matrix:
         arch: [32, 64]
 
-
     steps:
-
     - uses: actions/checkout@v2
       with:
         repository: facepunch/gmod-module-base

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,7 +31,7 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       with:
-        name: sdk-persistence-32
+        name: sdk-persistence-86
         path: ./sdk*
 
     # Dealing with the difference in the x64 steamworks requirements


### PR DESCRIPTION
The latest GarrysMod update has pushed support for x32 versions of GMod to Steamworks 153a. Frustratingly x64 has been left behind @ 150 so we'll need to account for this. 