### PR TITLE
Removes the GH:A master path being ignored

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -8,7 +8,6 @@ on:
       - "README.md"
       - 'examples/**'
       - ".gitignore"
-      - ".github/workflows/build-master.yml" 
       - ".github/workflows/build-pr.yml" 
 
 env:


### PR DESCRIPTION
Not intentional that the `master` path in the master workflow is ignored. 