### PR TITLE
Downgrade Steamworks to v1.50

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -73,7 +73,7 @@ jobs:
 
     - uses: actions/download-artifact@v2
       with:
-        name: sdk-persistence-${{matrix.arch}}
+        name: sdk-persistence-32
         path: gfwens/deps
 
     - uses: microsoft/setup-msbuild@v1.0.2
@@ -125,7 +125,7 @@ jobs:
 
     - uses: actions/download-artifact@v2
       with:
-        name: sdk-persistence-${{matrix.arch}}
+        name: sdk-persistence-32
         path: gfwens/deps
 
     - name: "Compile Binary"

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -72,7 +72,7 @@ jobs:
 
     - uses: actions/download-artifact@v2
       with:
-        name: sdk-persistence-${{matrix.arch}}
+        name: sdk-persistence-32
         path: gfwens/deps
 
     - uses: microsoft/setup-msbuild@v1.0.2
@@ -119,7 +119,7 @@ jobs:
 
     - uses: actions/download-artifact@v2
       with:
-        name: sdk-persistence-${{matrix.arch}}
+        name: sdk-persistence-32
         path: gfwens/deps
 
     - name: "Compile Binary"


### PR DESCRIPTION
With the latest gmod update Steamworks was downgraded to v1.50 for 32bit srcds. This PR just ensures that both binaries are using the v1.50 libs when building. 