### PR TITLE
Implement a more robust cleanup strategy

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -92,11 +92,6 @@ jobs:
         cd gfwens
         ./premake5.exe vs2019
         MSBuild.exe /p:Configuration=Release
-
-    - uses: actions/upload-artifact@v4
-      with:
-        name: gmsv_fwens_win${{matrix.arch}}.dll
-        path: gfwens\bin\release\gmsv_fwens_win${{matrix.arch}}.dll
 ###
 
   build-linux:
@@ -135,12 +130,6 @@ jobs:
         chmod +x ./premake5
         ./premake5 gmake2
         make config=release_x${{matrix.arch}}
-
-    - uses: actions/upload-artifact@v4
-      if: ${{ matrix.arch != 64 }}
-      with:
-        name: gmsv_fwens_linux.dll
-        path: gfwens/bin/release/gmsv_fwens_linux.dll
 
   release:
     name: Build Cleanup

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -92,6 +92,11 @@ jobs:
         cd gfwens
         ./premake5.exe vs2019
         MSBuild.exe /p:Configuration=Release
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: gmsv_fwens_win${{matrix.arch}}.dll
+        path: gfwens\bin\release\gmsv_fwens_win${{matrix.arch}}.dll
 ###
 
   build-linux:
@@ -130,6 +135,12 @@ jobs:
         chmod +x ./premake5
         ./premake5 gmake2
         make config=release_x${{matrix.arch}}
+
+    - uses: actions/upload-artifact@v4
+      if: ${{ matrix.arch != 64 }}
+      with:
+        name: gmsv_fwens_linux.dll
+        path: gfwens/bin/release/gmsv_fwens_linux.dll
 
   release:
     name: Build Cleanup

--- a/src/fwens.cpp
+++ b/src/fwens.cpp
@@ -36,11 +36,6 @@ void Fwens::Destroy()
 	}
 }
 
-bool Fwens::IsInstanceValid() 
-{
-	return instance != NULL;
-}
-
 void Fwens::SetLuaInstance(GarrysMod::Lua::ILuaBase* ILuaBase)
 {
 	LUA = ILuaBase;

--- a/src/fwens.cpp
+++ b/src/fwens.cpp
@@ -27,7 +27,7 @@ Fwens* Fwens::GetInstance()
 	return instance;
 }
 
-void Fwens::Destroy();
+void Fwens::Destroy()
 {
 	if (instance != NULL) 
 	{

--- a/src/fwens.cpp
+++ b/src/fwens.cpp
@@ -27,6 +27,20 @@ Fwens* Fwens::GetInstance()
 	return instance;
 }
 
+void Fwens::Destroy();
+{
+	if (instance != NULL) 
+	{
+		delete instance;
+		instance = NULL;
+	}
+}
+
+bool Fwens::IsInstanceValid() 
+{
+	return instance != NULL;
+}
+
 void Fwens::SetLuaInstance(GarrysMod::Lua::ILuaBase* ILuaBase)
 {
 	LUA = ILuaBase;

--- a/src/fwens.h
+++ b/src/fwens.h
@@ -13,11 +13,13 @@ private:
 public:
 	~Fwens();
 	static Fwens* GetInstance();
+	bool IsInstanceValid();
+	void Destroy();
 	void InitSteamAPIConnection();
 	bool GetSteamContextActive();
 	void SetLuaInstance(GarrysMod::Lua::ILuaBase* ILuaBase);
 	void RequestUserGroupStatus(CSteamID player, CSteamID groupID);
-	void ClearSteamContext();	
+	void ClearSteamContext();
 	void NotifyLuaSteamConnectionEvent(bool connected);
 	
 	STEAM_GAMESERVER_CALLBACK(Fwens, Steam_HandleSteamConnected, SteamServersConnected_t, m_steamcallback_HandleConnected);

--- a/src/fwens.h
+++ b/src/fwens.h
@@ -13,7 +13,7 @@ private:
 public:
 	~Fwens();
 	static Fwens* GetInstance();
-	bool IsInstanceValid();
+	static bool IsInstanceValid();
 	void Destroy();
 	void InitSteamAPIConnection();
 	bool GetSteamContextActive();

--- a/src/fwens.h
+++ b/src/fwens.h
@@ -14,7 +14,7 @@ public:
 	~Fwens();
 	static Fwens* GetInstance();
 	static bool IsInstanceValid();
-	void Destroy();
+	static void Destroy();
 	void InitSteamAPIConnection();
 	bool GetSteamContextActive();
 	void SetLuaInstance(GarrysMod::Lua::ILuaBase* ILuaBase);

--- a/src/fwens.h
+++ b/src/fwens.h
@@ -13,7 +13,6 @@ private:
 public:
 	~Fwens();
 	static Fwens* GetInstance();
-	static bool IsInstanceValid();
 	static void Destroy();
 	void InitSteamAPIConnection();
 	bool GetSteamContextActive();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,31 +85,7 @@ GMOD_MODULE_OPEN()
 
 GMOD_MODULE_CLOSE()
 {
-// #ifdef _WIN32
-// 	Fwens* fwenVar = Fwens::GetInstance();
-// 	delete fwenVar;
-// #endif
-
-	if (Fwens::IsInstanceValid())
-	{
-		LUA->PushSpecial(SPECIAL_GLOB);
-		LUA->CreateTable();
-		LUA->GetField(-1, "print");
-		LUA->PushString("we have a valid instance of fwens?");
-		LUA->Call(1, 0);
-
-		Fwens* fwenVar = Fwens::GetInstance();
-		delete fwenVar;
-	}
-	else
-	{
-		LUA->PushSpecial(SPECIAL_GLOB);
-		LUA->CreateTable();
-		LUA->GetField(-1, "print");
-		LUA->PushString("We dont have a valid instance of fwens?");
-		LUA->Call(1, 0);
-	}
-
+	Fwens::Destroy();
 	return 0;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,6 +89,7 @@ GMOD_MODULE_CLOSE()
 // 	Fwens* fwenVar = Fwens::GetInstance();
 // 	delete fwenVar;
 // #endif
+
 	if (Fwens::IsInstanceValid())
 	{
 		LUA->PushSpecial(SPECIAL_GLOB);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,6 +101,14 @@ GMOD_MODULE_CLOSE()
 		Fwens* fwenVar = Fwens::GetInstance();
 		delete fwenVar;
 	}
+	else
+	{
+		LUA->PushSpecial(SPECIAL_GLOB);
+		LUA->CreateTable();
+		LUA->GetField(-1, "print");
+		LUA->PushString("We dont have a valid instance of fwens?");
+		LUA->Call(1, 0);
+	}
 
 	return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,10 +85,22 @@ GMOD_MODULE_OPEN()
 
 GMOD_MODULE_CLOSE()
 {
-#ifdef _WIN32
-	Fwens* fwenVar = Fwens::GetInstance();
-	delete fwenVar;
-#endif
+// #ifdef _WIN32
+// 	Fwens* fwenVar = Fwens::GetInstance();
+// 	delete fwenVar;
+// #endif
+	if (Fwens::IsInstanceValid())
+	{
+		LUA->PushSpecial(SPECIAL_GLOB);
+		LUA->CreateTable();
+		LUA->GetField(-1, "print");
+		LUA->PushString("we have a valid instance of fwens?");
+		LUA->Call(1, 0);
+
+		Fwens* fwenVar = Fwens::GetInstance();
+		delete fwenVar;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
It looks like something has changed for linux srcds where it's definitely cleaning up objects, possibly due to how it might be killing the internal processes / memory. Instead of doing an OS check, we check to see now if `instance` is not `NULL`, and if it isn't we attempt to destroy it.

Furthermore, we encapsulate this in the static function `void Fwens::Destroy()` so that way the binary has a standard way of dealing with it. Doing it this way means that in future, should anything change in terms of how modules get unloaded on Windows (where `instance` can become NULL), these changes will already account for that. The same goes for Linux, where if the instance is no longer NULL, we'll attempt to clean it up!

Closes https://github.com/TeddiO/gFwens/issues/10